### PR TITLE
refs #php_8_0_compatibility Fix fatal error on the declaration of doT…

### DIFF
--- a/CRM/Core/Payment/KMOPayment.php
+++ b/CRM/Core/Payment/KMOPayment.php
@@ -71,7 +71,7 @@ class CRM_Core_Payment_KMOPayment extends CRM_Core_Payment {
    * @access public
    *
    */
-  function doTransferCheckout(&$params, $component) {
+  function doTransferCheckout(&$params, $component = 'contribute') {
 
     // Message.
     $message = E::ts("Process your payment with the 'kmo-portefeuille'.", ['domain' => 'be.ctrl.kmowallet']);


### PR DESCRIPTION
Fix fatal error on the declaration of doTransferCheckout so it matches declaration of its parent class' function.

This error occurs with PHP 8.0 when visiting an event (most likely had this payment method enabled).